### PR TITLE
script is doing the 3 brew commands automatically after brew installation

### DIFF
--- a/setup
+++ b/setup
@@ -7,6 +7,83 @@ echo "(that's a package manager for macOS)\n";
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)";
 
 
+# First check OS.
+OS="$(uname)"
+if [[ "${OS}" == "Linux" ]]
+then
+  HOMEBREW_ON_LINUX=1
+elif [[ "${OS}" == "Darwin" ]]
+then
+  HOMEBREW_ON_MACOS=1
+else
+  abort "Homebrew is only supported on macOS and Linux."
+fi
+
+# Required installation paths.
+case "${SHELL}" in
+  */bash*)
+    if [[ -r "${HOME}/.bash_profile" ]]
+    then
+      shell_profile="${HOME}/.bash_profile"
+    else
+      shell_profile="${HOME}/.profile"
+    fi
+    ;;
+  */zsh*)
+    shell_profile="${HOME}/.zprofile"
+    ;;
+  *)
+    shell_profile="${HOME}/.profile"
+    ;;
+esac
+
+if [[ -n "${HOMEBREW_ON_MACOS-}" ]]
+then
+  UNAME_MACHINE="$(/usr/bin/uname -m)"
+
+  if [[ "${UNAME_MACHINE}" == "arm64" ]]
+  then
+    # On ARM macOS, this script installs to /opt/homebrew only
+    HOMEBREW_PREFIX="/opt/homebrew"
+    HOMEBREW_REPOSITORY="${HOMEBREW_PREFIX}"
+  else
+    # On Intel macOS, this script installs to /usr/local only
+    HOMEBREW_PREFIX="/usr/local"
+    HOMEBREW_REPOSITORY="${HOMEBREW_PREFIX}/Homebrew"
+  fi
+  HOMEBREW_CACHE="${HOME}/Library/Caches/Homebrew"
+
+  STAT_PRINTF=("stat" "-f")
+  PERMISSION_FORMAT="%A"
+  CHOWN=("/usr/sbin/chown")
+  CHGRP=("/usr/bin/chgrp")
+  GROUP="admin"
+  TOUCH=("/usr/bin/touch")
+  INSTALL=("/usr/bin/install" -d -o "root" -g "wheel" -m "0755")
+else
+  UNAME_MACHINE="$(uname -m)"
+
+  # On Linux, this script installs to /home/linuxbrew/.linuxbrew only
+  HOMEBREW_PREFIX="/home/linuxbrew/.linuxbrew"
+  HOMEBREW_REPOSITORY="${HOMEBREW_PREFIX}/Homebrew"
+  HOMEBREW_CACHE="${HOME}/.cache/Homebrew"
+
+  STAT_PRINTF=("stat" "--printf")
+  PERMISSION_FORMAT="%a"
+  CHOWN=("/bin/chown")
+  CHGRP=("/bin/chgrp")
+  GROUP="$(id -gn)"
+  TOUCH=("/bin/touch")
+  INSTALL=("/usr/bin/install" -d -o "${USER}" -g "${GROUP}" -m "0755")
+fi
+
+# run the last three required steps from the brew installation script
+echo "Running the three lines requested above automatically"
+echo '# Set PATH, MANPATH, etc., for Homebrew.' >> ${shell_profile}
+echo eval "\"\$(${HOMEBREW_PREFIX}/bin/brew shellenv)"\" >> ${shell_profile}
+eval "$(${HOMEBREW_PREFIX}/bin/brew shellenv)"
+echo "Done!"
+
 # Install common tools
 echo "\n💻 \033[1mInstalling Command Line Tools…\033[0m";
 echo "(using the Homebrew package manager)\n";


### PR DESCRIPTION
# What was the problem
In the first step of the script, `brew` is installed. The normal installation of `brew` requires a manual input of three lines of code in the terminal after the installation process to put `brew` into `PATH` and get recognized from the OS.

In the current state of the script, the user has no opportunity to do that, because the script is running through. And there are a lot of errors, because the script can not find `brew` in `PAHT` and is not installation the software.

This pr fixes #2 this problem.

# What was done here
Line 10 to 78 makes sure, on what OS the script is running to create the important `${shell_profile}` and `${HOMEBREW_PREFIX}` variable. This was just copied from the `brew` install script.

The important part, where the magic happens, is line 80 to 85.

I tried the script with a new user on my M1 MacBook. This went through. Before merging this into `main` I really want to test it on a very new machine.

Pls try this script with this command and check if everything went well. Pls contact me if something went wrong.

```sh
zsh <(curl -s https://raw.githubusercontent.com/neuefische/web-setup/fix/script-is-doing-the-three-steps-after-brew-installation/setup)
```

If something went wrong, it is important to empty/delete the following lines in the `.zprofile` file. Because the script append it and when the script is running again, the lines are duplicated.

```
# Set PATH, MANPATH, etc., for Homebrew.' >> .zprofile
eval “$(/opt/homebrew/bin/brew shellenv)”
```
