### PR TITLE
Update mongodb-setup script

### DIFF
--- a/setup-mongodb
+++ b/setup-mongodb
@@ -5,8 +5,8 @@ echo "(Please follow the instructions in the terminal)\n";
 
 brew tap mongodb/brew &&
 brew update &&
-brew install mongodb-community &&
-brew services start mongodb-community &&
+brew install mongodb-community@5.0 &&
+brew services start mongodb-community@5.0 &&
 brew install --cask mongodb-compass
 
 echo "\n✨ \033[1m…all done!\033[0m";


### PR DESCRIPTION
This PR is a proposal for a fix of the [mongoDB versioning issue](https://github.com/neuefische/web-setup/issues/4).

I adjusted the mongoDB setup script to install `mongodb-community@5.0` instead of the latest version. 
I would suggest to have this script as an alternative for users with macOs Ventura, in addition to the already existing mongoDB setup script. 👉🏼 If we decide for this option, I will create an additional file for this script and adjust the readme file.

I tested the script on a Macbook with M1 chip and macOs Ventura - it worked fine for me. However, the script should be tested on other machines as well.